### PR TITLE
General backend cleanup

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -1,13 +1,26 @@
-# tasking-api
+# Demo
 
-Install packages
+This directory contains a demo site where several satelite providers
+have implemented proxies to map the STAT API to their existing
+provider-specific APIs.
+
+## Run locally
+
+### Install packages
 
 ```python
 pip install -r requirements.txt
 ```
 
-Run backend:
+Install next: [Next.js](https://nextjs.org/)
+
+### Run demo
 
 ```shell
 ./scripts/run
 ```
+
+### Access demo
+
+frontend: localhost:3000
+backend: localhost:8000

--- a/demo/api/backends/__init__.py
+++ b/demo/api/backends/__init__.py
@@ -6,9 +6,9 @@ from api.backends.planet_backend import PlanetBackend
 from api.backends.umbra_backend import UmbraBackend
 
 BACKENDS: dict[str, Backend] = {
-    "fake": FakeBackend,
-    "earthsearch": EarthSearchBackend,
-    "blacksky": BlackskyBackend,
-    "planet": PlanetBackend,
-    "umbra": UmbraBackend,
+    "fake": FakeBackend(),  # type: ignore
+    "earthsearch": EarthSearchBackend(),  # type: ignore
+    "blacksky": BlackskyBackend(),  # type: ignore
+    "planet": PlanetBackend(),  # type: ignore
+    "umbra": UmbraBackend(),  # type: ignore
 }

--- a/demo/api/backends/__init__.py
+++ b/demo/api/backends/__init__.py
@@ -1,8 +1,8 @@
 from api.backends.base import Backend
 from api.backends.blacksky_backend import BlackskyBackend
+from api.backends.earthsearch_backend import EarthSearchBackend
 from api.backends.fake_backend import FakeBackend
 from api.backends.planet_backend import PlanetBackend
-from api.backends.earthsearch_backend import EarthSearchBackend
 from api.backends.umbra_backend import UmbraBackend
 
 BACKENDS: dict[str, Backend] = {

--- a/demo/api/backends/__init__.py
+++ b/demo/api/backends/__init__.py
@@ -2,12 +2,12 @@ from api.backends.base import Backend
 from api.backends.blacksky_backend import BlackskyBackend
 from api.backends.fake_backend import FakeBackend
 from api.backends.planet_backend import PlanetBackend
-from api.backends.sentinel_backend import HistoricalBackend
+from api.backends.earthsearch_backend import EarthSearchBackend
 from api.backends.umbra_backend import UmbraBackend
 
 BACKENDS: dict[str, Backend] = {
     "fake": FakeBackend,
-    "historical": HistoricalBackend,
+    "earthsearch": EarthSearchBackend,
     "blacksky": BlackskyBackend,
     "planet": PlanetBackend,
     "umbra": UmbraBackend,

--- a/demo/api/backends/base.py
+++ b/demo/api/backends/base.py
@@ -3,21 +3,18 @@ from typing import Protocol
 from api.models import Opportunity, Order, Product
 
 
-# backend protocol class
 class Backend(Protocol):
-    """Backend Python API"""
+    """
+    Protocol class that backend provider APIs must conform to
 
-    async def find_opportunities(
-        self,
-        search: Opportunity,
-        token: str,
-    ) -> list[Opportunity]:
-        return NotImplemented
-
+    In order to create a backend a provider must create a class
+    with the methods defined in this Protocol.
+    """
     async def find_products(
         self,
         token: str,
     ) -> list[Product]:
+        """Get a list of all Products"""
         return NotImplemented
 
     async def place_order(
@@ -25,4 +22,13 @@ class Backend(Protocol):
         search: Opportunity,
         token: str,
     ) -> Order:
+        """Given an Opportunity, place an order"""
+        return NotImplemented
+
+    async def find_opportunities(
+        self,
+        search: Opportunity,
+        token: str,
+    ) -> list[Opportunity]:
+        """Given an Opportunity, get a list of Opportunites that fulfill it"""
         return NotImplemented

--- a/demo/api/backends/base.py
+++ b/demo/api/backends/base.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from api.api_types import OpportunityCollection, Order, Product, Search
+from api.models import OpportunityCollection, Order, Product, Search
 
 
 # backend protocol class

--- a/demo/api/backends/base.py
+++ b/demo/api/backends/base.py
@@ -10,6 +10,7 @@ class Backend(Protocol):
     In order to create a backend a provider must create a class
     with the methods defined in this Protocol.
     """
+
     async def find_products(
         self,
         token: str,

--- a/demo/api/backends/base.py
+++ b/demo/api/backends/base.py
@@ -1,6 +1,6 @@
 from typing import Protocol
 
-from api.models import OpportunityCollection, Order, Product, Search
+from api.models import Opportunity, Order, Product
 
 
 # backend protocol class
@@ -9,9 +9,9 @@ class Backend(Protocol):
 
     async def find_opportunities(
         self,
-        search: Search,
+        search: Opportunity,
         token: str,
-    ) -> OpportunityCollection:
+    ) -> list[Opportunity]:
         return NotImplemented
 
     async def find_products(
@@ -22,7 +22,7 @@ class Backend(Protocol):
 
     async def place_order(
         self,
-        search: Search,
+        search: Opportunity,
         token: str,
     ) -> Order:
         return NotImplemented

--- a/demo/api/backends/blacksky_backend.py
+++ b/demo/api/backends/blacksky_backend.py
@@ -1,6 +1,6 @@
 import requests
 
-from api.api_types import Opportunity, OpportunityCollection, Search
+from api.models import Opportunity, OpportunityCollection, Search
 
 BLACKSKY_BASE_URL = "https://api.dev.blacksky.com/v1"
 

--- a/demo/api/backends/blacksky_backend.py
+++ b/demo/api/backends/blacksky_backend.py
@@ -55,14 +55,14 @@ def get_oppurtunities(blacksky_request, token):
     return r.json()["opportunities"]
 
 
-def oppurtunity_to_stat(iw):
+def blacksky_oppurtunity_to_opportunity(iw):
     """
     translates a Planet Imaging Windows into a STAC item
     :param iw: an element from the 'imaging_windows' array of a /imaging_windows/[search_id] response
     :return: a corresponding STAC item
     """
 
-    item = Opportunity(
+    opportunity = Opportunity(
         id=iw["satellite"],
         product_id="BS-Test:Standard",
         geometry={"type": "Point", "coordinates": [iw["longitude"], iw["latitude"], 0]},
@@ -73,7 +73,7 @@ def oppurtunity_to_stat(iw):
         },
     )
 
-    return item
+    return opportunity
 
 
 class BlackskyBackend:
@@ -84,4 +84,4 @@ class BlackskyBackend:
     ) -> list[Opportunity]:
         blacksky_request = stat_to_oppurtunities_request(search_request)
         oppurtunities = get_oppurtunities(blacksky_request, token)
-        return [oppurtunity_to_stat(iw) for iw in oppurtunities]
+        return [blacksky_oppurtunity_to_opportunity(iw) for iw in oppurtunities]

--- a/demo/api/backends/blacksky_backend.py
+++ b/demo/api/backends/blacksky_backend.py
@@ -1,5 +1,4 @@
 import requests
-
 from api.models import Opportunity
 
 BLACKSKY_BASE_URL = "https://api.dev.blacksky.com/v1"
@@ -67,7 +66,7 @@ def blacksky_oppurtunity_to_opportunity(iw):
         product_id="BS-Test:Standard",
         geometry={"type": "Point", "coordinates": [iw["longitude"], iw["latitude"], 0]},
         datetime=f"{iw['timestamp']}/{iw['timestamp']}",
-        constraints = {
+        constraints={
             "off_nadir": iw["offNadirAngleDegrees"],
             "cloud_cover": iw["weatherForecast"]["cloudCover"],
         },

--- a/demo/api/backends/earthsearch_backend.py
+++ b/demo/api/backends/earthsearch_backend.py
@@ -2,18 +2,17 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import pystac
+from api.models import (
+    Opportunity,
+    Order,
+    Product,
+    ProductConstraints,
+    ProductParameters,
+    Provider,
+)
 from geojson_pydantic.geometries import Point
 from pystac import Collection, ItemCollection
 from pystac_client.client import Client
-
-from api.models import (
-    Order,
-    Product,
-    Provider,
-    ProductConstraints,
-    ProductParameters,
-    Opportunity,
-)
 
 DEFAULT_MAX_ITEMS = 10
 MAX_MAX_ITEMS = 100
@@ -28,9 +27,9 @@ PRODUCT_IDS = [LANDSAT_COLLECTION_ID, SENTINEL_COLLECTION_ID]
 TIME_DELTA = timedelta(days=3 * 365)
 
 
-def adjust_datetime(value: str) -> str:
-    date = datetime.fromisoformat(value.replace("Z", "+00:00"))
-    return f"{(date + TIME_DELTA).isoformat()}/{(date + TIME_DELTA).isoformat()}"
+def adjust_datetime(value: datetime) -> str:
+    date = value + TIME_DELTA
+    return f"{date.isoformat()}/{date.isoformat()}"
 
 
 def stac_item_to_opportunity(item: pystac.Item, product_id: str) -> Opportunity:
@@ -39,7 +38,9 @@ def stac_item_to_opportunity(item: pystac.Item, product_id: str) -> Opportunity:
     return Opportunity(
         geometry=Point(coordinates=(point_vals[0], point_vals[1])),
         product_id=product_id,
-        datetime=adjust_datetime(item.datetime),
+        datetime=adjust_datetime(item.datetime)
+        if item.datetime
+        else f"{item.properties['start_datetime']/item.properties['end_datetime']}",
         id=item.id,
     )
 

--- a/demo/api/backends/earthsearch_backend.py
+++ b/demo/api/backends/earthsearch_backend.py
@@ -82,7 +82,7 @@ def stac_collection_to_product(collection: Collection) -> Product:
     )
 
 
-class HistoricalBackend:
+class EarthSearchBackend:
     catalog: Client
 
     def __init__(self) -> None:

--- a/demo/api/backends/earthsearch_backend.py
+++ b/demo/api/backends/earthsearch_backend.py
@@ -8,9 +8,16 @@ from geojson_pydantic.geometries import Point
 from pystac import Collection, ItemCollection
 from pystac_client.client import Client
 
-from api.models import (Opportunity, OpportunityCollection,
-                           OpportunityProperties, Order, Product,
-                           ProductConstraints, Provider, Search)
+from api.models import (
+    Opportunity,
+    OpportunityCollection,
+    OpportunityProperties,
+    Order,
+    Product,
+    ProductConstraints,
+    Provider,
+    Search,
+)
 
 DEFAULT_MAX_ITEMS = 10
 MAX_MAX_ITEMS = 100
@@ -89,7 +96,7 @@ class EarthSearchBackend:
         self.catalog = Client.open("https://earth-search.aws.element84.com/v1")  # type: ignore
 
     def _search(self, search) -> ItemCollection:
-        max_items = min(search.limit, MAX_MAX_ITEMS)
+        max_items = DEFAULT_MAX_ITEMS
 
         args: dict[str, Any] = {
             "collections": [search.product_id],

--- a/demo/api/backends/earthsearch_backend.py
+++ b/demo/api/backends/earthsearch_backend.py
@@ -8,7 +8,7 @@ from geojson_pydantic.geometries import Point
 from pystac import Collection, ItemCollection
 from pystac_client.client import Client
 
-from api.api_types import (Opportunity, OpportunityCollection,
+from api.models import (Opportunity, OpportunityCollection,
                            OpportunityProperties, Order, Product,
                            ProductConstraints, Provider, Search)
 

--- a/demo/api/backends/fake_backend.py
+++ b/demo/api/backends/fake_backend.py
@@ -1,4 +1,4 @@
-from api.models import Product, Provider, Opportunity
+from api.models import Opportunity, Product, Provider
 
 
 class FakeBackend:

--- a/demo/api/backends/fake_backend.py
+++ b/demo/api/backends/fake_backend.py
@@ -1,6 +1,6 @@
 import pystac
 
-from api.api_types import (Opportunity, OpportunityCollection, Product,
+from api.models import (Opportunity, OpportunityCollection, Product,
                            Provider, Search)
 
 STAC_ITEM_URL = (

--- a/demo/api/backends/fake_backend.py
+++ b/demo/api/backends/fake_backend.py
@@ -1,7 +1,6 @@
 import pystac
 
-from api.models import (Opportunity, OpportunityCollection, Product,
-                           Provider, Search)
+from api.models import Opportunity, OpportunityCollection, Product, Provider, Search
 
 STAC_ITEM_URL = (
     "https://raw.githubusercontent.com/stac-utils/pystac/main/"

--- a/demo/api/backends/fake_backend.py
+++ b/demo/api/backends/fake_backend.py
@@ -1,32 +1,17 @@
-import pystac
-
-from api.models import Opportunity, OpportunityCollection, Product, Provider, Search
-
-STAC_ITEM_URL = (
-    "https://raw.githubusercontent.com/stac-utils/pystac/main/"
-    "tests/data-files/item/sample-item.json"
-)
+from api.models import Product, Provider, Opportunity
 
 
 class FakeBackend:
     async def find_opportunities(
         self,
-        search: Search,
+        search: Opportunity,
         token: str,
-    ) -> OpportunityCollection:
-        item = pystac.Item.from_file(STAC_ITEM_URL)
-        opportunity = Opportunity(geometry=item.geometry, properties=item.properties)
-        opportunity_collection = OpportunityCollection(features=[opportunity])
-        return opportunity_collection
+    ) -> list[Opportunity]:
+        return [search]
 
     async def find_products(self, token: str) -> list[Product]:
-        # todo: get real list of products
-        # todo: consider proper reactions for all types of products
         return [
             Product(
-                type="Product",
-                stat_version="0.0.1",
-                stat_extensions=[],
                 id="fake product",
                 title="fake product",
                 description="",

--- a/demo/api/backends/planet_backend.py
+++ b/demo/api/backends/planet_backend.py
@@ -3,12 +3,12 @@ import time
 
 import requests
 
-from api.models import Opportunity, OpportunityCollection, Product, Provider, Search
+from api.models import Product, Provider, Opportunity
 
 PLANET_BASE_URL = "https://api.staging.planet-labs.com"
 
 
-def search_to_imaging_window_request(search_request: Search) -> dict:
+def search_to_imaging_window_request(search_request: Opportunity) -> dict:
     """
     :param search: search object as passed on to find_opportunities
     :return: a corresponding request to retrieve imaging windows
@@ -73,14 +73,11 @@ def imaging_window_to_opportunity(iw, geom, search_request) -> Opportunity:
     return Opportunity(
         id=iw["id"],
         geometry=geom,
-        properties={
-            "title": "Planet Assured Imaging Window @ " + iw["start_time"],
-            "datetime": f"{iw['start_time']}/{iw['end_time']}",
-            "product_id": search_request.product_id,
-            "constraints": {
-                "off_nadir": [iw["start_off_nadir"], iw["end_off_nadir"]],
-                "cloud_cover": iw["cloud_forecast"][0]["prediction"],
-            },
+        datetime=f"{iw['start_time']}/{iw['end_time']}",
+        product_id=search_request.product_id,
+        constraints= {
+            "off_nadir": [iw["start_off_nadir"], iw["end_off_nadir"]],
+            "cloud_cover": iw["cloud_forecast"][0]["prediction"],
         },
     )
 
@@ -88,9 +85,9 @@ def imaging_window_to_opportunity(iw, geom, search_request) -> Opportunity:
 class PlanetBackend:
     async def find_opportunities(
         self,
-        search_request: Search,
+        search_request: Opportunity,
         token: str,
-    ) -> OpportunityCollection:
+    ) -> list[Opportunity]:
         # this assumes we have an Assured product i.e. one which is ordered with respect to a
         # specific imaging window
         # todo: extend this flow to flexible orders
@@ -106,7 +103,7 @@ class PlanetBackend:
         # todo: combine original request and returned imaging window such that the returned
         #   opportunities are a valid order structure
 
-        return OpportunityCollection(features=opportunities)
+        return opportunities
 
     async def find_products(self, token: str) -> list[Product]:
         # todo: get real list of products

--- a/demo/api/backends/planet_backend.py
+++ b/demo/api/backends/planet_backend.py
@@ -2,8 +2,7 @@ import os
 import time
 
 import requests
-
-from api.models import Product, Provider, Opportunity
+from api.models import Opportunity, Product, Provider
 
 PLANET_BASE_URL = "https://api.staging.planet-labs.com"
 
@@ -57,7 +56,7 @@ def get_imaging_windows(planet_request, token: str) -> list:
             return r.json()["imaging_windows"]
         elif status == "FAILED":
             raise ValueError(
-                f"Retrieving Imaging Windows failed: {r.json['error_code']} - {r.json['error_message']}'"
+                f"Retrieving Imaging Windows failed: {r.json()['error_code']} - {r.json()['error_message']}'"
             )
         # todo async
         time.sleep(1)
@@ -75,7 +74,7 @@ def imaging_window_to_opportunity(iw, geom, search_request) -> Opportunity:
         geometry=geom,
         datetime=f"{iw['start_time']}/{iw['end_time']}",
         product_id=search_request.product_id,
-        constraints= {
+        constraints={
             "off_nadir": [iw["start_off_nadir"], iw["end_off_nadir"]],
             "cloud_cover": iw["cloud_forecast"][0]["prediction"],
         },

--- a/demo/api/backends/planet_backend.py
+++ b/demo/api/backends/planet_backend.py
@@ -3,7 +3,7 @@ import time
 
 import requests
 
-from api.api_types import (Opportunity, OpportunityCollection, Product,
+from api.models import (Opportunity, OpportunityCollection, Product,
                            Provider, Search)
 
 PLANET_BASE_URL = "https://api.staging.planet-labs.com"

--- a/demo/api/backends/planet_backend.py
+++ b/demo/api/backends/planet_backend.py
@@ -3,8 +3,7 @@ import time
 
 import requests
 
-from api.models import (Opportunity, OpportunityCollection, Product,
-                           Provider, Search)
+from api.models import Opportunity, OpportunityCollection, Product, Provider, Search
 
 PLANET_BASE_URL = "https://api.staging.planet-labs.com"
 

--- a/demo/api/backends/umbra_backend.py
+++ b/demo/api/backends/umbra_backend.py
@@ -8,9 +8,15 @@ from pydantic import BaseModel, Field
 from pystac import ProviderRole
 from stac_pydantic.shared import Provider
 
-from api.models import (Geometry, Opportunity, OpportunityCollection,
-                           OpportunityProperties, Product, Search)
 from api.backends.base import Backend
+from api.models import (
+    Geometry,
+    Opportunity,
+    OpportunityCollection,
+    OpportunityProperties,
+    Product,
+    Search,
+)
 
 UMBRA_BASE_URL = os.getenv("UMBRA_BASE_URL")
 UMBRA_FEASIBILITIES_URL = f"{UMBRA_BASE_URL}/tasking/feasibilities"

--- a/demo/api/backends/umbra_backend.py
+++ b/demo/api/backends/umbra_backend.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, Field
 from pystac import ProviderRole
 from stac_pydantic.shared import Provider
 
-from api.api_types import (Geometry, Opportunity, OpportunityCollection,
+from api.models import (Geometry, Opportunity, OpportunityCollection,
                            OpportunityProperties, Product, Search)
 from api.backends.base import Backend
 

--- a/demo/api/backends/umbra_backend.py
+++ b/demo/api/backends/umbra_backend.py
@@ -1,19 +1,13 @@
 import asyncio
 import os
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 from uuid import UUID, uuid4
 
 import requests
+from api.backends.base import Backend
+from api.models import Geometry, Opportunity, Product, Provider
 from pydantic import BaseModel, Field
 from pystac import ProviderRole
-from stac_pydantic.shared import Provider
-
-from api.backends.base import Backend
-from api.models import (
-    Geometry,
-    Product,
-    Opportunity,
-)
 
 UMBRA_BASE_URL = os.getenv("UMBRA_BASE_URL")
 UMBRA_FEASIBILITIES_URL = f"{UMBRA_BASE_URL}/tasking/feasibilities"
@@ -52,7 +46,7 @@ def search_to_feasibility_request_payload(search: Opportunity) -> Dict[str, Any]
 
 
 def umbra_opportunity_to_opportunity(
-    opportunity: Dict[str, Any], geom: Optional[Geometry]
+    opportunity: Dict[str, Any], geom: Geometry
 ) -> Opportunity:
     return Opportunity(
         id=f"umb-spotlight: {str(uuid4())}",
@@ -72,7 +66,9 @@ def umbra_opportunity_to_opportunity(
     )
 
 
-def get_feasibility_request_id(search_request: Opportunity, headers: Dict[str, str]) -> str:
+def get_feasibility_request_id(
+    search_request: Opportunity, headers: Dict[str, str]
+) -> str:
     payload = search_to_feasibility_request_payload(search_request)
     response = requests.post(
         UMBRA_FEASIBILITIES_URL,
@@ -89,7 +85,7 @@ def get_feasibility_request_id(search_request: Opportunity, headers: Dict[str, s
 
 def get_umbra_opportunities(
     feasibility_request_id: str, headers: Dict[str, str]
-) -> Optional[List[Dict[str, Any]]]:
+) -> Optional[list[Dict[str, Any]]]:
     response = requests.get(
         f"{UMBRA_FEASIBILITIES_URL}/{feasibility_request_id}",
         headers=headers,
@@ -106,7 +102,7 @@ def get_umbra_opportunities(
 
 
 class UmbraSpotlightParameters(BaseModel):
-    data_products: List[
+    data_products: list[
         Literal["GEC"] | Literal["SICD"] | Literal["SIDD"] | Literal["CPHD"]
     ] = Field(title="Requested Data Products", default_factory=lambda: ["GEC"])
     delivery_config_id: UUID | None = Field(title="DeliveryConfig ID", default=None)

--- a/demo/api/main.py
+++ b/demo/api/main.py
@@ -3,13 +3,17 @@ from datetime import datetime, timedelta
 from functools import wraps
 from typing import Tuple
 
+from api.backends import BACKENDS
+from api.backends.base import Backend
+from api.models import (
+    Opportunity,
+    OpportunityCollection,
+    Order,
+    ProductCollection,
+)
 from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from geojson_pydantic import Point
-
-from api.backends import BACKENDS
-from api.backends.base import Backend
-from api.models import OpportunityCollection, Order, Product, ProductCollection, Opportunity
 
 app = FastAPI(title="Tasking API")
 
@@ -41,7 +45,7 @@ def _get_backend_and_token(request: Request) -> Tuple[Backend, str]:
         token = authorization.replace("Bearer ", "")
 
     if backend_name in BACKENDS:
-        backend: Backend = BACKENDS[backend_name]()
+        backend: Backend = BACKENDS[backend_name]
     else:
         raise HTTPException(
             status_code=404,

--- a/demo/api/main.py
+++ b/demo/api/main.py
@@ -13,7 +13,7 @@ from api.backends.base import Backend
 
 app = FastAPI(title="Tasking API")
 
-DEFAULT_BACKEND = os.environ.get("DEFAULT_BACKEND", "historical")
+DEFAULT_BACKEND = os.environ.get("DEFAULT_BACKEND", "earthsearch")
 
 
 def throw(func):

--- a/demo/api/main.py
+++ b/demo/api/main.py
@@ -9,7 +9,7 @@ from geojson_pydantic import Point
 
 from api.backends import BACKENDS
 from api.backends.base import Backend
-from api.models import OpportunityCollection, Order, Product, Search
+from api.models import OpportunityCollection, Order, Product, ProductCollection, Opportunity
 
 app = FastAPI(title="Tasking API")
 
@@ -55,12 +55,13 @@ async def redirect_home():
     return RedirectResponse("/docs")
 
 
-@app.get("/products", response_model=list[Product])
+@app.get("/products", response_model=ProductCollection)
 @throw
 async def get_products(request: Request):
     backend, token = _get_backend_and_token(request)
+    products = await backend.find_products(token=token)
 
-    return await backend.find_products(token=token)
+    return ProductCollection(products=products)
 
 
 @app.get("/products/{id}/opportunities", response_model=OpportunityCollection)
@@ -68,7 +69,7 @@ async def get_products(request: Request):
 async def get_product_opportunities(
     id: str,
     request: Request,
-    search: Search | None = None,
+    search: Opportunity | None = None,
 ):
     """Get opportunities for a given product
 
@@ -79,24 +80,25 @@ async def get_product_opportunities(
     if search is None:
         start_datetime = datetime.now()
         end_datetime = start_datetime + timedelta(days=40)
-        search = Search(
+        search = Opportunity(
             geometry=Point(coordinates=(45, 45)),
             datetime=f"{start_datetime.isoformat()}/{end_datetime.isoformat()}",
             product_id=id,
         )
     search.product_id = id
 
-    return await backend.find_opportunities(
+    opportunities = await backend.find_opportunities(
         search,
         token=token,
     )
+    return OpportunityCollection.from_opportunities(opportunities)
 
 
 @app.get("/opportunities", response_model=OpportunityCollection)
 @throw
 async def get_opportunities(
     request: Request,
-    search: Search | None = None,
+    search: Opportunity | None = None,
 ):
     backend, token = _get_backend_and_token(request)
 
@@ -104,37 +106,39 @@ async def get_opportunities(
         start_datetime = datetime.now()
         end_datetime = start_datetime + timedelta(days=40)
         product_id = "landsat-c2-l2"
-        search = Search(
+        search = Opportunity(
             geometry=Point(coordinates=(45, 45)),
             datetime=f"{start_datetime.isoformat()}/{end_datetime.isoformat()}",
             product_id=product_id,
         )
 
-    return await backend.find_opportunities(
+    opportunities = await backend.find_opportunities(
         search,
         token=token,
     )
+    return OpportunityCollection.from_opportunities(opportunities)
 
 
 @app.post("/opportunities", response_model=OpportunityCollection)
 @throw
 async def post_opportunities(
     request: Request,
-    search: Search,
+    search: Opportunity,
 ):
     backend, token = _get_backend_and_token(request)
 
-    return await backend.find_opportunities(
+    opportunities = await backend.find_opportunities(
         search,
         token=token,
     )
+    return OpportunityCollection.from_opportunities(opportunities)
 
 
 @app.post("/orders", response_model=Order)
 @throw
 async def post_order(
     request: Request,
-    search: Search,
+    search: Opportunity,
 ):
     backend, token = _get_backend_and_token(request)
 

--- a/demo/api/main.py
+++ b/demo/api/main.py
@@ -7,7 +7,7 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from geojson_pydantic import Point
 
-from api.api_types import OpportunityCollection, Order, Product, Search
+from api.models import OpportunityCollection, Order, Product, Search
 from api.backends import BACKENDS
 from api.backends.base import Backend
 

--- a/demo/api/main.py
+++ b/demo/api/main.py
@@ -7,9 +7,9 @@ from fastapi import FastAPI, HTTPException, Request
 from fastapi.responses import RedirectResponse
 from geojson_pydantic import Point
 
-from api.models import OpportunityCollection, Order, Product, Search
 from api.backends import BACKENDS
 from api.backends.base import Backend
+from api.models import OpportunityCollection, Order, Product, Search
 
 app = FastAPI(title="Tasking API")
 
@@ -82,7 +82,7 @@ async def get_product_opportunities(
         search = Search(
             geometry=Point(coordinates=(45, 45)),
             datetime=f"{start_datetime.isoformat()}/{end_datetime.isoformat()}",
-            limit=10,
+            product_id=id,
         )
     search.product_id = id
 
@@ -107,7 +107,6 @@ async def get_opportunities(
         search = Search(
             geometry=Point(coordinates=(45, 45)),
             datetime=f"{start_datetime.isoformat()}/{end_datetime.isoformat()}",
-            limit=10,
             product_id=product_id,
         )
 

--- a/demo/api/models.py
+++ b/demo/api/models.py
@@ -11,11 +11,10 @@ from geojson_pydantic.geometries import (
     Point,
     Polygon,
 )
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, constr
 from pydantic.datetime_parse import parse_datetime
 from stac_pydantic.collection import Range
 from stac_pydantic.links import Link
-
 
 Geometry = Union[
     Point,
@@ -32,13 +31,13 @@ ProductConstraints = Dict[str, Union[Range, tuple, list[Any], Dict[str, Any]]]
 ProductParameters = Dict[str, Union[Range, tuple, list[Any], Dict[str, Any]]]
 
 
-# derived from stac_pydantic.Provider
+# derived from stac_pydantic.shared.Provider
 class Provider(BaseModel):
     """
     https://github.com/radiantearth/stac-spec/blob/v1.0.0/collection-spec/collection-spec.md#provider-object
     """
 
-    name: str = Field(const=True)
+    name: constr(min_length=1)
     description: Optional[str] = Field(default=None)
     roles: Optional[list[str]] = Field(default=None)
     url: Optional[str] = Field(default=None)

--- a/demo/api/models.py
+++ b/demo/api/models.py
@@ -8,8 +8,7 @@ from geojson_pydantic.geometries import (GeometryCollection, LineString,
 from pydantic import BaseModel, Field
 from pydantic.datetime_parse import parse_datetime
 from stac_pydantic.collection import Range
-from stac_pydantic.links import Link
-from stac_pydantic.shared import Provider
+
 
 Geometry = Union[
     Point,

--- a/demo/api/tests/test_api.py
+++ b/demo/api/tests/test_api.py
@@ -65,7 +65,7 @@ def test_post_to_opportunities_with_opportunities_body():
     assert "features" in response.json()
 
 
-@pytest.mark.parametrize("backend", ["fake", "historical"])
+@pytest.mark.parametrize("backend", ["fake", "earthsearch"])
 def test_post_to_opportunities_with_opportunities_body_and_header(backend: str):
     response = client.post(
         "/opportunities",
@@ -81,7 +81,7 @@ def test_products_authenticated(backend_and_token: Tuple[str, str]):
     _test_products(backend, token)
 
 
-@pytest.mark.parametrize("backend", ["fake", "historical"])
+@pytest.mark.parametrize("backend", ["fake", "earthsearch"])
 def test_products_unauthenticated(backend: str):
     _test_products(backend)
 
@@ -140,7 +140,7 @@ def test_post_to_orders_raises_if_not_possible():
     product_id = "landsat-c2-l2"
     response = client.post(
         "/orders",
-        headers={"Backend": "historical"},
+        headers={"Backend": "earthsearch"},
         json={"product_id": product_id, **VALID_SEARCH_BODY},
     )
     assert response.status_code == 500
@@ -158,7 +158,7 @@ def test_post_to_orders():
     }
     response = client.post(
         "/orders",
-        headers={"Backend": "historical"},
+        headers={"Backend": "earthsearch"},
         json=json_body,
     )
     assert response.status_code == 200

--- a/demo/api/tests/test_api.py
+++ b/demo/api/tests/test_api.py
@@ -7,7 +7,7 @@ from typing import Optional, Tuple
 import pytest
 from fastapi.testclient import TestClient
 
-from api.api_types import Opportunity, OpportunityCollection, Order, Search
+from api.models import Opportunity, OpportunityCollection, Order, Search
 from api.backends import BACKENDS
 from api.main import app
 

--- a/demo/api/tests/test_api.py
+++ b/demo/api/tests/test_api.py
@@ -9,7 +9,7 @@ from fastapi.testclient import TestClient
 
 from api.backends import BACKENDS
 from api.main import app
-from api.models import Opportunity, OpportunityCollection, Order, Search
+from api.models import OpportunityFeature, OpportunityCollection, Order, Opportunity
 
 LOGGER = logging.getLogger(__name__)
 
@@ -112,7 +112,7 @@ def test_post_to_opportunities_with_opportunities_body_and_header_authenticated(
     search_body_now = {
         "datetime": f"{start_time.isoformat()}/{end_time.isoformat()}",
         "geometry": {"type": "Point", "coordinates": [-75.16, 39.95]},
-        "product_id": "",
+        "product_id": "fake_product",
     }
 
     response = client.post(
@@ -173,15 +173,15 @@ def test_token_is_passed_to_backend(endpoint):
     class MockBackend:
         async def find_opportunities(
             self,
-            search: Search,
+            search: Opportunity,
             token: str,
-        ) -> Opportunity:
+        ) -> OpportunityFeature:
             assert token == TOKEN
             return OpportunityCollection(features=[])
 
         async def place_order(
             self,
-            search: Search,
+            search: Opportunity,
             token: str,
         ) -> Order:
             assert token == TOKEN

--- a/demo/api/tests/test_api.py
+++ b/demo/api/tests/test_api.py
@@ -5,11 +5,10 @@ import os
 from typing import Optional, Tuple
 
 import pytest
-from fastapi.testclient import TestClient
-
 from api.backends import BACKENDS
 from api.main import app
-from api.models import OpportunityFeature, OpportunityCollection, Order, Opportunity
+from api.models import Opportunity, Order
+from fastapi.testclient import TestClient
 
 LOGGER = logging.getLogger(__name__)
 
@@ -175,9 +174,9 @@ def test_token_is_passed_to_backend(endpoint):
             self,
             search: Opportunity,
             token: str,
-        ) -> OpportunityFeature:
+        ) -> list[Opportunity]:
             assert token == TOKEN
-            return OpportunityCollection(features=[])
+            return []
 
         async def place_order(
             self,
@@ -187,7 +186,7 @@ def test_token_is_passed_to_backend(endpoint):
             assert token == TOKEN
             return Order(id="blahblahblah")
 
-    BACKENDS["mock"] = MockBackend
+    BACKENDS["mock"] = MockBackend()
 
     client.post(
         endpoint,

--- a/demo/app/src/components/Sidebar/OpportunityList.js
+++ b/demo/app/src/components/Sidebar/OpportunityList.js
@@ -20,7 +20,7 @@ function mouseOutStyleChange(e) {
             const { start, end } = parseStacDatetime(opp.properties.datetime);
             return <Opportunity
                 key={index}
-                title={opp.properties.title}
+                title={opp.id}
                 start={start}
                 end={end}
                 // onMouseEnter={(e) => {

--- a/demo/app/src/context/appContext.js
+++ b/demo/app/src/context/appContext.js
@@ -21,7 +21,7 @@ export default function AppProvider({ children }) {
       today,
       new Date(new Date(today).setDate(today.getDate() + 3)),
     ],
-    provider: 'historical'
+    provider: 'earthsearch'
   });
   const [hoveredOpportunity, setHoveredOpportunity] = useState(null);
   const [selectedOpportunity, setSelectedOpportunity] = useState(null);
@@ -32,7 +32,7 @@ export default function AppProvider({ children }) {
         params: {
           "geometry": userParams.geometry,
           "datetime": formatToISOString(userParams.dateRange),
-          "product_id": userParams.provider === 'historical' ? 'sentinel-2-l1c' : null
+          "product_id": userParams.provider === 'earthsearch' ? 'sentinel-2-l1c' : null
         },
         provider: userParams.provider
       } : null;
@@ -41,8 +41,8 @@ export default function AppProvider({ children }) {
   const { isLoading: isLoadingOpps, data: opportunities, error: errorOpps } = usePostRequest(postParams);
   const { isLoading: isLoadingProducts, data: products, error: errorProducts } = useGetRequest();
   const providers = [{
-    id: 'historical',
-    name: 'Historical'
+    id: 'earthsearch',
+    name: 'EarthSearch'
   }, {
     id: 'blacksky',
     name: 'BlackSky'

--- a/demo/app/src/hooks/useGetRequest.js
+++ b/demo/app/src/hooks/useGetRequest.js
@@ -9,7 +9,7 @@ const useGetRequest = () => {
         fetch('/api/products')
         .then((res) => res.json())
         .then((data) => {
-            setData(data)
+            setData(data['products'])
             setIsLoading(false)
         }).catch(e => setError(e));
     }, []);


### PR DESCRIPTION
This PR adds descriptions to the model fields and makes it simpler to create new backends for providers.

The big change is that the backend protocol changes so that the input to `find_opportunities` is the same type as elements in the list of outputs. I think this will make it easier to write new backends and it consolidates the mapping from list of `Opportunity` (not geojson) to `OpportunityCollection` (valid geojson FeatureCollection). 

Note about class names: in this PR Opportunity is the input to `/opportunities` and `/order` (on main this is called `Search`).