### PR TITLE
Use CQL2, clarify data types and request scheams, etc.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,13 +45,12 @@ column is more of an example in some cases.
 
 | Endpoint                    | Specified in  | Accepts                                                      | Returns                                                      | Description                                                  |
 | --------------------------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| `GET /`                     | Core          | -                                                            | [Landing Page](#landing-page)                                                 |                                                              |
+| `GET /`                     | Core          | -                                                            | [Landing Page](#landing-page)                                |                                                              |
 | `GET /products`             | Core          | -                                                            | [Products Collection](./product/README.md)                   | Figure out which constraints are available for which `product_id` |
 | `GET /products/{productId}` | Core          | -                                                            | [Product](./product/README.md)                               |                                                              |
 | `GET /orders`               | Core          | -                                                            | [Orders Collection](./order/README.md#order-collection)      |                                                              |
 | `POST /orders`              | Core          | [Order Request](./order/README.md#order-request)             | [Order Object](./order/README.md#order-pobject)              | Order a capture with a particular set of constraints         |
-| `GET /opportunities`        | Opportunities | -                                                            | [Opportunities Collection](./opportunity/README.md#opportunities-collection) |                                                              |
-| `POST /opportunities`       | Opportunities | [Opportunity Request](./opportunity/README.md#opportunity-request) | [Opportunity Object](./opportunity/README.md#opportunity-object) | Explore the opportunities available for a particular set of constraints |
+| `POST /opportunities`       | Opportunities | [Opportunity Request](./opportunity/README.md#opportunity-request) | [Opportunities Collection](./opportunity/README.md#opportunities-collection) | Explore the opportunities available for a particular set of constraints |
 
 ## Conformance Classes
 

--- a/README.md
+++ b/README.md
@@ -43,15 +43,15 @@ The following table describes the service resources available in a STAT API impl
 supports all three of the foundation specifications. Note that the 'Endpoint'
 column is more of an example in some cases.
 
-| Endpoint                       | Specified in   | Returns                       | Description  |
-| ------------------------------ | -------------- | ----------------------------- | ------------ |
-| `/`                            | Core           | [?]()                         | |
-| `/products`                    | Core           | [ProductsCollection](./product) | Figure out which constraints are available for which `product_id` |
-| `/orders`                      | Core           | [OrdersCollection](./order)     |  |
-| POST `/orders`                 | Core           | [Order](./order)                | Order a capture with a particular set of constraints |
-| `/products/{productId}`        | Core           | [Product](./product)                   | |
-| `/opportunities`               | Opportunities  | [OpportunitiesCollection](./opportunity)   | |
-| POST `/opportunities`          | Opportunities  | [OpportunitiesCollection](./opportunity)    | Explore the opportunities available for a particular set of constraints |
+| Endpoint                    | Specified in  | Accepts                                                      | Returns                                                      | Description                                                  |
+| --------------------------- | ------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
+| `GET /`                     | Core          | -                                                            | [Landing Page](#landing-page)                                                 |                                                              |
+| `GET /products`             | Core          | -                                                            | [Products Collection](./product/README.md)                   | Figure out which constraints are available for which `product_id` |
+| `GET /products/{productId}` | Core          | -                                                            | [Product](./product/README.md)                               |                                                              |
+| `GET /orders`               | Core          | -                                                            | [Orders Collection](./order/README.md#order-collection)      |                                                              |
+| `POST /orders`              | Core          | [Order Request](./order/README.md#order-request)             | [Order Object](./order/README.md#order-pobject)              | Order a capture with a particular set of constraints         |
+| `GET /opportunities`        | Opportunities | -                                                            | [Opportunities Collection](./opportunity/README.md#opportunities-collection) |                                                              |
+| `POST /opportunities`       | Opportunities | [Opportunity Request](./opportunity/README.md#opportunity-request) | [Opportunity Object](./opportunity/README.md#opportunity-object) | Explore the opportunities available for a particular set of constraints |
 
 ## Conformance Classes
 
@@ -71,13 +71,12 @@ requires they also live at the `/conformance` endpoint. STAT's conformance struc
 
 See [the STAT API Demo](https://github.com/Element84/stat-api-demo)
 
-## Example Landing Page
+## Landing Page
 
 The Landing Page will at least have the following `conformsTo` and `links`:
 
 ```json
 {
-    "stat_version": "0.1.0",
     "id": "example-stat-api",
     "title": "A simple STAT API Example",
     "description": "This API demonstrated the landing page for a SpatioTemporal Asset Tasking API",

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -2,7 +2,20 @@
 
 The STAT Opportunity describes a window of opportunity available for ordering.
 
-## Opportunity fields
+# Opportunity Request
+
+for POST /opportunities
+
+| Field Name | Type                                                                       | Description |
+| ---------- | -------------------------------------------------------------------------- | ----------- |
+| datetime       | string                                                                     | **REQUIRED.** Datetime field is a [ISO8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) |
+| product_id         | string                                                                     | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the constraints which can be used in the constraints field. |
+| geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
+| filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
+
+## Opportunity Response
+
+for GET /opportunities in the `opportunities` array.
 
 This object describes a STAT Opportunity. The input fields will be contained `properties` of each Feature in the GeoJSON response.
 
@@ -15,7 +28,6 @@ This object describes a STAT Opportunity. The input fields will be contained `pr
 | bbox       | \[number]                                                                  | **REQUIRED if `geometry` is not `null`.** Bounding Box of the asset represented by this Item, formatted according to [RFC 7946, section 5](https://tools.ietf.org/html/rfc7946#section-5). |
 | properties | [Properties Object](#properties-object)                                    | **REQUIRED.** A dictionary of additional metadata for the Item. |
 | links      | \[[Link Object](#link-object)]                                             | List of link objects to resources and related URLs. |
-| constraints | Map<string, \[\*]\|[Range Object](#range-object)\|[JSON Schema Object](#json-schema-object)> | A map of opportunity constraints, either a set of values, a range of values or a JSON Schema. |
 
 ### Additional Field Information
 

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -11,7 +11,7 @@ for POST /opportunities
 | datetime       | string                                                                     | **REQUIRED.** Datetime field is a [ISO8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) |
 | product_id         | string                                                                     | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the constraints which can be used in the constraints field. |
 | geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
-| filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
+| filter | CQL2 Object | A set of additional constraints in [CQL2 JSON](https://docs.ogc.org/DRAFTS/21-065.html) based on the constraints exposed in the product. |
 
 ## Opportunity Collection
 

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -15,7 +15,7 @@ for POST /opportunities
 
 ## Opportunity Collection
 
-for GET /opportunities
+for POST /opportunities
 
 This is a GeoJSON FeatureCollection.
 

--- a/opportunity/README.md
+++ b/opportunity/README.md
@@ -2,7 +2,7 @@
 
 The STAT Opportunity describes a window of opportunity available for ordering.
 
-# Opportunity Request
+## Opportunity Request
 
 for POST /opportunities
 
@@ -13,9 +13,19 @@ for POST /opportunities
 | geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
 | filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
 
-## Opportunity Response
+## Opportunity Collection
 
-for GET /opportunities in the `opportunities` array.
+for GET /opportunities
+
+This is a GeoJSON FeatureCollection.
+
+| Field Name    | Type                      | Description |
+| ------------- | ------------------------- | ----------- |
+| type          | string                    | **REQUIRED.** Always `FeatureCollection`. |
+| features      | \[Opportunity Object\]    | **REQUIRED.** A list of opportunities. |
+| links         | Map\<object, Link Object> | **REQUIRED.** Links for e.g. pagination. |
+
+### Opportunity Object
 
 This object describes a STAT Opportunity. The input fields will be contained `properties` of each Feature in the GeoJSON response.
 
@@ -29,8 +39,6 @@ This object describes a STAT Opportunity. The input fields will be contained `pr
 | properties | [Properties Object](#properties-object)                                    | **REQUIRED.** A dictionary of additional metadata for the Item. |
 | links      | \[[Link Object](#link-object)]                                             | List of link objects to resources and related URLs. |
 
-### Additional Field Information
-
 #### bbox
 
 Bounding Box of the asset represented by this Item using either 2D or 3D geometries,
@@ -43,7 +51,7 @@ and the elevation of the northeasterly most extent is the maximum.
 This field enables more naive clients to easily index and search geospatially.
 STAC compliant APIs are required to compute intersection operations with the Item's geometry field, not its bbox.
 
-### Properties Object
+#### Properties Object
 
 Additional metadata fields can be added to the GeoJSON Object Properties. The only required field
 is `datetime` but it is recommended to add more fields, see [Additional Fields](#additional-fields)

--- a/order/README.md
+++ b/order/README.md
@@ -4,19 +4,21 @@ This document explains the structure of a STAT **Order** request which is used f
 
 Ordering with loosely defined order values will give the provider more freedom to schedule. Define the values strictly to increase the chance of the preferred capture moment.
 
-Endpoint: GET /order, POST /order
+# Order Request
 
-# Order Spec
+for POST /orders
 
 | Field Name | Type                                                                       | Description |
 | ---------- | -------------------------------------------------------------------------- | ----------- |
 | datetime       | string                                                                     | **REQUIRED.** Datetime field is a [ISO8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) |
 | product_id         | string                                                                     | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the constraints which can be used in the constraints field. |
 | geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
-| constraints | Map<string, \[\*]\|[Range Object](#range-object)\|[JSON Schema Object](#json-schema-object)> | STRONGLY RECOMMENDED. A map of opportunity constraints, either a set of values, a range of values or a JSON Schema.
+| filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
 
 
 # Order Response
+
+for GET /orders in the `orders` array.
 
 | Field Name | Type | Description |
 | ---------- | ---- | ----------- |

--- a/order/README.md
+++ b/order/README.md
@@ -13,7 +13,7 @@ for POST /orders
 | datetime       | string                                                                     | **REQUIRED.** Datetime field is a [ISO8601 Time Interval](https://en.wikipedia.org/wiki/ISO_8601#Time_intervals) |
 | product_id         | string                                                                     | **REQUIRED.** Product identifier. The ID should be unique and is a reference to the constraints which can be used in the constraints field. |
 | geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
-| filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
+| filter | CQL2 JSON | A set of additional constraints in [CQL2 JSON](https://docs.ogc.org/DRAFTS/21-065.html) based on the constraints exposed in the product. |
 
 ## Order Collection
 

--- a/order/README.md
+++ b/order/README.md
@@ -4,7 +4,7 @@ This document explains the structure of a STAT **Order** request which is used f
 
 Ordering with loosely defined order values will give the provider more freedom to schedule. Define the values strictly to increase the chance of the preferred capture moment.
 
-# Order Request
+## Order Request
 
 for POST /orders
 
@@ -15,10 +15,16 @@ for POST /orders
 | geometry   | [GeoJSON Geometry Object](https://tools.ietf.org/html/rfc7946#section-3.1) | **REQUIRED.** Defines the full footprint of the asset represented by this item, formatted according to [RFC 7946, section 3.1](https://tools.ietf.org/html/rfc7946#section-3.1). The footprint should be the default GeoJSON geometry, though additional geometries can be included. Coordinates are specified in Longitude/Latitude or Longitude/Latitude/Elevation based on [WGS 84](http://www.opengis.net/def/crs/OGC/1.3/CRS84). |
 | filter | CQL2 JSON | A set of additional constraints in CQL2 JSON based on the constraints exposed in the product. |
 
+## Order Collection
 
-# Order Response
+for GET /orders
 
-for GET /orders in the `orders` array.
+| Field Name | Type                      | Description |
+| ---------- | ------------------------- | ----------- |
+| orders     | \[Order Object\]          | **REQUIRED.** A list of orders. |
+| links      | Map\<object, Link Object> | **REQUIRED.** Links for e.g. pagination. |
+
+### Order Object
 
 | Field Name | Type | Description |
 | ---------- | ---- | ----------- |

--- a/product/README.md
+++ b/product/README.md
@@ -16,8 +16,8 @@ STAT Product objects are represented in JSON format and are very flexible. Any J
 | license         | string                                           | **REQUIRED.** Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases. |
 | providers       | \[[Provider Object](#provider-object)]           | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |                |
 | links           | \[[Link Object](#link-object)]                   | **REQUIRED.** A list of references to other documents.       |
-| constraints | Map<string, [Constraints Object](#constraints-object)> | User supplied constraints on a tasking request|
-| parameters | [Parameters Object](#parameters-object) | User supplied parameters that don't constrain tasking (e.g., output format)|
+| constraints | Map<string, [Constraints Object](#constraints-object)> | User supplied constraints on a tasking request |
+| parameters | [Parameters Object](#parameters-object) | User supplied parameters that don't constrain tasking (e.g., output format) |
 
 
 ### Provider Object

--- a/product/README.md
+++ b/product/README.md
@@ -16,9 +16,8 @@ STAT Product objects are represented in JSON format and are very flexible. Any J
 | license         | string                                           | **REQUIRED.** Collection's license(s), either a SPDX [License identifier](https://spdx.org/licenses/), `various` if multiple licenses apply or `proprietary` for all other cases. |
 | providers       | \[[Provider Object](#provider-object)]           | A list of providers, which may include all organizations capturing or processing the data or the hosting provider. Providers should be listed in chronological order with the most recent provider being the last element of the list. |                |
 | links           | \[[Link Object](#link-object)]                   | **REQUIRED.** A list of references to other documents.       |
-| constraints | Map<string, [ConstraintsObject](#constraints-object)> | User supplied constraints on a tasking request|
-| parameters | [ParametersObject](#parameters-object) | User supplied parameters that don't constrain tasking (e.g., output format)|
-| properties | [PropertiesObject](#properties-object) | REQUIRED. A dictionary of additional metadata for the Item.|
+| constraints | Map<string, [Constraints Object](#constraints-object)> | User supplied constraints on a tasking request|
+| parameters | [Parameters Object](#parameters-object) | User supplied parameters that don't constrain tasking (e.g., output format)|
 
 
 ### Provider Object
@@ -59,35 +58,28 @@ For a full discussion of the situations where relative and absolute links are re
 ['Use of links'](../best-practices.md#use-of-links) section of the STAC best practices.
 
 ### Constraints Object
+
 Constraints are limitations imposed by the user and the data provider as to what data is desired, and what data is available. In addition to space, time, and product limitations, constraints filter the needs of the user and capacity of the provider through an API negotiation. Constraints build off STAC extensions and modify them in order to support ranges of values.
 
 Users of the Tasking API Should follow STAC Extension naming conventions when adding constraints.
 
+A Constraints Object is a definitions for fine-grained information, see the [JSON Schema Object](#json-schema-object) section for more.
 
-The constraints for a field can be specified in three ways:
+It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
+to align with the JSON Schemas provided by STAC. Empty schemas are not allowed.
 
-1. A set of all distinct values in an array: The set of values must contain at least one element and it is strongly recommended to list all values.
-2. A Range in a [Range Object](#range-object): Statistics by default only specify the range (minimum and maximum values),
-   but can optionally be accompanied by additional statistical values.
-   The range specified by the `minimum` and `maximum` properties can specify the potential range of values,
-   but it is recommended to be as precise as possible.
-3. Extensible JSON Schema definitions for fine-grained information, see the [JSON Schema Object](#json-schema-object)
-   section for more.
+For an introduction to JSON Schema, see "[Learn JSON Schema](https://json-schema.org/learn/)".
 
 ### Parameters Object
 
 Parameters are objects which do not affect the Tasking process, but are nevertheless useful. For example, a user may wish to select a preferred output format or a data provider may provide additional metadata about a product.
 
+A Constraints Object is a definitions for fine-grained information, see the [JSON Schema Object](#json-schema-object) section for more.
 
-A summary for a field can be specified in three ways:
+It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
+to align with the JSON Schemas provided by STAC. Empty schemas are not allowed.
 
-1. A set of all distinct values in an array: The set of values must contain at least one element and it is strongly recommended to list all values.
-2. A Range in a [Range Object](#range-object): Statistics by default only specify the range (minimum and maximum values),
-   but can optionally be accompanied by additional statistical values.
-   The range specified by the `minimum` and `maximum` properties can specify the potential range of values,
-   but it is recommended to be as precise as possible.
-3. Extensible JSON Schema definitions for fine-grained information, see the [JSON Schema Object](#json-schema-object)
-   section for more.
+For an introduction to JSON Schema, see "[Learn JSON Schema](https://json-schema.org/learn/)".
 
 ### Range Object
 
@@ -102,17 +94,6 @@ Implementors are free to add other derived statistical values to the object, for
 | ---------- | -------------- | ----------- |
 | minimum    | number\|string | **REQUIRED.** Minimum value. |
 | maximum    | number\|string | **REQUIRED.** Maximum value. |
-
-### JSON Schema Object
-
-For a full understanding of the summarized field, a JSON Schema can be added for each summarized field.
-This allows very fine-grained information for each field and each value as JSON Schema is also extensible.
-Each schema must be valid against all corresponding values available for the property in the sub-Items.
-
-It is recommended to use [JSON Schema draft-07](https://json-schema.org/specification-links.html#draft-7)
-to align with the JSON Schemas provided by STAC. Empty schemas are not allowed.
-
-For an introduction to JSON Schema, see "[Learn JSON Schema](https://json-schema.org/learn/)".
 
 ### Properties Object
 

--- a/stat.yaml
+++ b/stat.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.3
+openapi: 3.1.0
 info:
   title: STAT API - Core
   version: v0.1.0
@@ -236,10 +236,8 @@ components:
           type: string
         geometry:
           $ref: "https://geojson.org/schema/Geometry.json"
-        constraints:
-          $ref: "#/components/schemas/jsonschemas"
-        parameters:
-          $ref: "#/components/schemas/jsonschemas"
+        filters:
+          $ref: "#/components/schemas/cql2"
     license:
       type: string
       description: |-
@@ -355,9 +353,9 @@ components:
         links:
           $ref: "#/components/schemas/links"
         constraints:
-          $ref: "#/components/schemas/jsonschemas"
+          $ref: "#/components/schemas/jsonschema"
         parameters:
-          $ref: "#/components/schemas/jsonschemas"
+          $ref: "#/components/schemas/jsonschema"
     links:
       type: array
       items:
@@ -409,12 +407,11 @@ components:
               NOTE: To support form encoding it is expected that a client be able
               to merge in the key value pairs specified as JSON
               `{"next": "token"}` will become `&next=token`.
-    jsonschemas:
-      type: object
-      additionalProperties:
-        $ref: '#/components/schemas/jsonschema'
     jsonschema:
         title: JSON Schema
+        type: object
+    cql2:
+        title: CQL2 JSON
         type: object
     conformanceClasses:
       type: object


### PR DESCRIPTION
Update the constraints to use CQL2 as discussed + cleanup properties as discussed in the Wed morning session. Fixes #119

Also adds docs for the Order and Opportunity Collections. Fixes #120

Update README with accepts column. Fixes  #116

Clairfy JSON Schema requirement for constraints. Fixes #118 and #119

Clarify Accept & Return values from endpoints. FIxes #132

Remove GET /opportunities because it's undefined. Partially solves #98